### PR TITLE
Fix "No Hat" when reading

### DIFF
--- a/SkyReader-GUI/Hats.vb
+++ b/SkyReader-GUI/Hats.vb
@@ -435,7 +435,7 @@ Public Class Hats
         'MessageBox.Show(Hat(0))
         Try
             If Hat(0) = &H0 Then
-                frmMain.cmbHat.SelectedItem = "None"
+                frmMain.cmbHat.SelectedItem = "No Hat"
             ElseIf Hat(0) = &HE Then
                 frmMain.cmbHat.SelectedItem = "Anvil Hat"
             ElseIf Hat(0) = &H2C Then


### PR DESCRIPTION
If you had a hat other than "No Hat" selected in the GUI, then read a figure which has No Hat, the GUI would still show the previous hat, rather than showing "No Hat". This PR fixes that.