### PR TITLE
Fix writing Experience, blanking unused parts

### DIFF
--- a/SkyReader-GUI/Exp.vb
+++ b/SkyReader-GUI/Exp.vb
@@ -296,6 +296,10 @@ Public Class Exp
                 WholeFile(&H119) = EXP3(1)
                 WholeFile(&H11A) = EXP3(2)
                 'MessageBox.Show("Area0")
+			Else
+				WholeFile(&H118) = &H0
+           		WholeFile(&H119) = &H0
+        		WholeFile(&H11A) = &H0
             End If
         Else
             WholeFile(&H113) = &H0
@@ -317,6 +321,10 @@ Public Class Exp
                 WholeFile(&H2D8) = EXP3(0)
                 WholeFile(&H2D9) = EXP3(1)
                 WholeFile(&H2DA) = EXP3(2)
+        	Else
+				WholeFile(&H2D8) = &H0
+           		WholeFile(&H2D9) = &H0
+        		WholeFile(&H2DA) = &H0
             End If
         Else
             WholeFile(&H2D3) = &H0


### PR DESCRIPTION
This pull request fixes the situation where the Exp level is *lowered* from, say, 17 to 12. The issue was that in that situation, the three bytes at 118, 119 and 11A (and the equivalent three bytes in the other area) were not blanked. When the experience is read from the figure, those three (non-zero) bytes are read and added to the experience level, making the experience level higher than the intended 12 in this example.

I have copied your coding style as much as possible in the commit, but actually it would seem safer and neater to me to always blank the seven experience bytes first, before writing those that are needed. This would eliminate having to blank the unused bytes in the "Else" sections, giving something like:
```
        WholeFile(&H113) = &H0
        WholeFile(&H114) = &H0
        WholeFile(&H118) = &H0
        WholeFile(&H119) = &H0
        WholeFile(&H11A) = &H0

        WholeFile(&H80) = EXP1(0)
        WholeFile(&H81) = EXP1(1)
        If frmMain.numLevel.Value > 10 Then
            WholeFile(&H113) = EXP2(0)
            WholeFile(&H114) = EXP2(1)
            If frmMain.numLevel.Value > 15 Then
                WholeFile(&H118) = EXP3(0)
                WholeFile(&H119) = EXP3(1)
                WholeFile(&H11A) = EXP3(2)
                'MessageBox.Show("Area0")
            End If
        End If
```

Or even better, given that the code above sets all seven bytes correctly anyway, including setting unused ones to zero, e.g. in sections like this:
```
	Case 12
		'53900-66599 is Level 12
		EXP1 = BitConverter.GetBytes(33000)
		EXP2 = BitConverter.GetBytes(20900)
		EXP3 = BitConverter.GetBytes(0)
```
then you could simply write all seven bytes as is, without needing any If statements at all, e.g. just:
```
        WholeFile(&H80) = EXP1(0)
        WholeFile(&H81) = EXP1(1)
        WholeFile(&H113) = EXP2(0)
        WholeFile(&H114) = EXP2(1)
        WholeFile(&H118) = EXP3(0)
        WholeFile(&H119) = EXP3(1)
        WholeFile(&H11A) = EXP3(2)
```

Let me know if you would prefer a pull request of this simpler form. Or just implement it that way yourself!

Thanks.